### PR TITLE
Tablet Bottom module view aangepast

### DIFF
--- a/templates/jc/index.php
+++ b/templates/jc/index.php
@@ -150,19 +150,19 @@ if (!empty($analyticsData) && $analyticsData['position'] == 'after_body_start')
 	<div class="footer-navs">
 		<div class="container">
 			<div class="row">
-				<div class="col-4">
+				<div class="col-sm-12 col-md-12 col-lg-4">
 					<jdoc:include type="modules" name="footer-1" style="xhtml"/>
 				</div>
-				<div class="col-2">
+				<div class="col-sm-12 col-md-3 col-lg-2">
 					<jdoc:include type="modules" name="footer-2" style="xhtml"/>
 				</div>
-				<div class="col-2">
+				<div class="col-sm-12  col-md-3  col-lg-2 ">
 					<jdoc:include type="modules" name="footer-3" style="xhtml"/>
 				</div>
-				<div class="col-2">
+				<div class="col-sm-12  col-md-3  col-lg-2 ">
 					<jdoc:include type="modules" name="footer-4" style="xhtml"/>
 				</div>
-				<div class="col-2">
+				<div class="col-sm-12  col-md-3  col-lg-2 ">
 					<jdoc:include type="modules" name="footer-5" style="xhtml"/>
 				</div>
 			</div>


### PR DESCRIPTION
Layout aangepast voor Bottom. Opmerking: bij heel smal verdwenen (en verdwijnen) deze modules

**Nieuwe view voor large en up**
<img width="1011" alt="schermafbeelding 2016-09-10 om 10 41 17" src="https://cloud.githubusercontent.com/assets/5138117/18409296/d4bfaba4-7743-11e6-8b52-1f52d90327d1.png">
**Nieuwe view voor medium**
<img width="902" alt="schermafbeelding 2016-09-10 om 10 41 25" src="https://cloud.githubusercontent.com/assets/5138117/18409295/d4bdf7aa-7743-11e6-8659-ffe1733b21d6.png">
**Nieuwe view voor small**
<img width="714" alt="schermafbeelding 2016-09-10 om 10 41 33" src="https://cloud.githubusercontent.com/assets/5138117/18409297/d4c09244-7743-11e6-81b8-ee2cbb4f099b.png">
