### PR TITLE
Voorkom problemen bij update naar 3.8

### DIFF
--- a/public_html/plugins/system/bootstrap3compatibility/fields/media.php
+++ b/public_html/plugins/system/bootstrap3compatibility/fields/media.php
@@ -1,3 +1,3 @@
 <?php
 
-require_once JPATH_SITE . '/libraries/cms/form/field/media.php';
+require_once JPATH_SITE . '/libraries/src/Form/Field/MediaField.php';


### PR DESCRIPTION
Deze PR voorkomt problemen bij het updaten naar Joomla! 3.8. In de plugin bootstrap3compatibiliy wordt een bestand van de Joomla! core ingeladen. Echter met de komst van de J4compatibility layer is dit bestand verplaatst, en klopt de import niet meer.